### PR TITLE
[EDC-2490] Fix issue when loading edc-help from an invalid link

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'fr.techad'
-version '2.5.1-SNAPSHOT'
+version '2.5.2-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven-publish'
@@ -22,7 +22,7 @@ dependencies {
     compile group: 'com.google.inject', name: 'guice', version: '4.1.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
-    compile group: 'fr.techad', name: 'edc-client', version: '2.4.0-snapshot'
+    compile group: 'fr.techad', name: 'edc-client', version: '2.4.1-snapshot'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/src/main/java/fr/techad/edc/popover/internal/swing/builder/ContextualContentComponentBuilderImpl.java
+++ b/src/main/java/fr/techad/edc/popover/internal/swing/builder/ContextualContentComponentBuilderImpl.java
@@ -124,7 +124,7 @@ public class ContextualContentComponentBuilderImpl implements ContextualContentC
                 linkPanel.add(linkContentPanel, BorderLayout.CENTER);
                 for (DocumentationItem documentationItem : contextItem.getLinks()) {
                     LOGGER.debug("Display link: {}", documentationItem);
-                    String url = edcClient.getDocumentationWebHelpUrl(documentationItem.getId(), contextItem.getLanguageCode());
+                    String url = edcClient.getDocumentationWebHelpUrl(documentationItem.getId(), contextItem.getLanguageCode(), contextItem.getPublicationId());
                     linkContentPanel.add(createButton(url, documentationItem.getLabel()));
                 }
                 body.add(linkPanel, BorderLayout.CENTER);


### PR DESCRIPTION
- Add the publicationId in the the edc-help documentation url,
to allow edc-help to load the right context if the target link was not
valid
- set version to 2.5.2-SNAPSHOT

Epic [EDC-1796]